### PR TITLE
Patch

### DIFF
--- a/RewriteJson.pro.user
+++ b/RewriteJson.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.3.1, 2017-08-08T17:13:19. -->
+<!-- Written by QtCreator 4.3.1, 2017-08-09T15:28:14. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
@@ -54,7 +54,9 @@
  </data>
  <data>
   <variable>ProjectExplorer.Project.PluginSettings</variable>
-  <valuemap type="QVariantMap"/>
+  <valuemap type="QVariantMap">
+   <valuelist type="QVariantList" key="ClangStaticAnalyzer.SuppressedDiagnostics"/>
+  </valuemap>
  </data>
  <data>
   <variable>ProjectExplorer.Project.Target.0</variable>

--- a/dialog.cpp
+++ b/dialog.cpp
@@ -16,6 +16,7 @@ Dialog::Dialog(QWidget *parent):
     new_UiDialog->NewTableWidget->setSpan(0, 1, 1, 2);//combine cells
     new_UiDialog->NewTableWidget->setSpan(1, 1, 1, 2);
     new_UiDialog->NewTableWidget->setSpan(2, 1, 1, 2);
+    new_UiDialog->NewTableWidget->setSpan(4, 1, 1, 2);
 
     connect(new_UiDialog->addNew,SIGNAL(clicked()),this,SLOT(finish_edit()));
     connect(new_UiDialog->clearNew,SIGNAL(clicked()),this,SLOT(clear_edit()));
@@ -46,7 +47,7 @@ void Dialog::initNewTable(int i, int j)
     item4->setFlags(item4->flags()&(~Qt::ItemIsEditable));
     new_UiDialog->NewTableWidget->setItem(4,0,item4);
 
-    QTableWidgetItem *item5 = new QTableWidgetItem(NULL);
+    QTableWidgetItem *item5 = new QTableWidgetItem();
     item5->setFlags(item5->flags()&(~Qt::ItemIsEditable));
     new_UiDialog->NewTableWidget->setItem(4,1,item5);
 }
@@ -223,7 +224,7 @@ void Dialog::clear_edit()
     item4->setFlags(item4->flags()&(~Qt::ItemIsEditable));
     new_UiDialog->NewTableWidget->setItem(4,0,item4);
 
-    QTableWidgetItem *item5 = new QTableWidgetItem(NULL);
+    QTableWidgetItem *item5 = new QTableWidgetItem();
     item5->setFlags(item5->flags()&(~Qt::ItemIsEditable));
     new_UiDialog->NewTableWidget->setItem(4,1,item5);
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -48,12 +48,10 @@ void MainWindow::showTableWidget()
     int addItemNum;
     if(parent == NULL)
     {
-        QString frame_num = newitemlocation->text(0).remove(0,6);
-        addFrameNum = frame_num.toInt()-1;
+        addFrameNum = ui->treeJsonFile->indexOfTopLevelItem(newitemlocation);
         addItemNum = frame_start[addFrameNum]-1;
     }else{
-        QString frame_num = newitemlocation->parent()->text(0).remove(0,6);
-        addFrameNum = frame_num.toInt()-1;
+        addFrameNum = ui->treeJsonFile->indexOfTopLevelItem(parent);
         int frame_start_num = frame_start[addFrameNum];
         int row=parent->indexOfChild(newitemlocation);
         addItemNum = frame_start_num+row;
@@ -75,14 +73,14 @@ void MainWindow::on_actionOpen_clicked()
      QString filedir = QFileDialog::getOpenFileName(this, tr("Open File"),"/home/liamzhang/samurai_data/",tr("Json Files(*.json)"));
      if (filedir.isEmpty())
      {
-         QMessageBox::warning(this,"Warning","Fail to get a Json file",QMessageBox::Yes);
+         QMessageBox::warning(this,"Warning",tr("Fail to get a Json file"),QMessageBox::Yes);
          return;
      }
 
      std::ifstream fin(filedir.toStdString().c_str());
      if (!fin.is_open())
      {
-          QMessageBox::warning(this,"Warnning","Can't open the Json file",QMessageBox::Yes);
+          QMessageBox::warning(this,"Warnning",tr("Can't open the Json file"),QMessageBox::Yes);
           return;
      }
 
@@ -283,7 +281,7 @@ void MainWindow::on_treeJsonFile_itemSelectionChanged()
         QTableWidgetItem *item4 = new QTableWidgetItem("arg:");
         item4->setFlags(item4->flags()&(~Qt::ItemIsEditable));
         ui->ItemInformation->setItem(currentTableRow,0,item4);
-        QTableWidgetItem *item5 = new QTableWidgetItem(NULL);
+        QTableWidgetItem *item5 = new QTableWidgetItem();
         item5->setFlags(item5->flags()&(~Qt::ItemIsEditable));
         ui->ItemInformation->setItem(currentTableRow,1,item5);
         QJsonArray argtype = selectItemObject["5 arg_type"].toArray();
@@ -443,9 +441,8 @@ void MainWindow::on_actionSetChange_clicked()
     int frame_start_num = frame_start[num];
     int row=parent->indexOfChild(item);
     int changedItemNum = frame_start_num+row;
-
     int currentTableRow = 0;
-    resave_string.removeAt(changedItemNum+1);
+    resave_string.removeAt(changedItemNum);
 
     QJsonObject changedItemObject;
     if(ui->ItemInformation->item(currentTableRow,1) == NULL){return;}

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -54,8 +54,6 @@ private slots:
 
     void showtheChange(int framenum, int callnum, QJsonObject addItemObject, QString addText);
 
-
-
 private:
     Ui::MainWindow *ui;
     QStringList resave_string;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -146,7 +146,7 @@
     <item row="0" column="0">
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <layout class="QHBoxLayout" name="horizontalLayout_1">
         <item>
          <widget class="QPushButton" name="actionOpen">
           <property name="sizePolicy">
@@ -210,7 +210,7 @@
        </widget>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
          <widget class="QLineEdit" name="Filter">
           <property name="sizePolicy">


### PR DESCRIPTION
(1)Debug the "set change" function rewrites the wrong call.
(2)Change the way in which "new" function get the current frame ID so that overcome the bug when click this button after one frame was removed.
(3)Merge two cells following the arguments cell in the new dialog and set it uneditable.